### PR TITLE
refactor: matcher refactoring

### DIFF
--- a/examples/custom-matcher/src/main.rs
+++ b/examples/custom-matcher/src/main.rs
@@ -1,4 +1,4 @@
-use streamson_lib::{handler, matcher, Collector};
+use streamson_lib::{handler, matcher, path::Path, Collector};
 
 use std::sync::{Arc, Mutex};
 
@@ -17,8 +17,8 @@ impl Letter {
 }
 
 impl matcher::MatchMaker for Letter {
-    fn match_path(&self, path: &str) -> bool {
-        path.chars().any(|c| c == self.letter)
+    fn match_path(&self, path: &Path) -> bool {
+        path.to_string().chars().any(|c| c == self.letter)
     }
 }
 

--- a/examples/serde/src/main.rs
+++ b/examples/serde/src/main.rs
@@ -32,7 +32,7 @@ impl handler::Handler for UserHandler {
 
 fn main() {
     let handler = Arc::new(Mutex::new(UserHandler::default()));
-    let matcher = matcher::Simple::new(r#"{"users"}[]"#);
+    let matcher = matcher::Simple::new(r#"{"users"}[]"#).unwrap();
 
     Collector::new().add_matcher(
         Box::new(matcher), &[handler.clone()]).process(br#"{"users": [{"firstname": "Carl", "surname": "Streamson"}, {"firstname": "Stream", "surname": "Carlson"}]}"#).unwrap();

--- a/streamson-lib/README.md
+++ b/streamson-lib/README.md
@@ -15,7 +15,7 @@ use streamson_lib::{Collector, GenericError, PrintLn, Simple};
 
 let mut collector = Collector::new();
 let handler = Arc::new(Mutex::new(PrintLn::new());
-let matcher = Simple(r#"{"users"}[]"#);
+let matcher = Simple(r#"{"users"}[]"#).unwrap();
 collector = collector.add_matcher(Box::new(matcher), &[handler]);
 
 let mut buffer = [0; 2048];

--- a/streamson-lib/benches/basic.rs
+++ b/streamson-lib/benches/basic.rs
@@ -21,8 +21,8 @@ fn gen_input() -> Vec<Vec<u8>> {
 pub fn simple(c: &mut Criterion) {
     let mut collector = Collector::new();
 
-    let first_matcher = matcher::Simple::new(r#"{"users"}[]"#);
-    let second_matcher = matcher::Simple::new(r#"{"logs"}[]"#);
+    let first_matcher = matcher::Simple::new(r#"{"users"}[]"#).unwrap();
+    let second_matcher = matcher::Simple::new(r#"{"logs"}[]"#).unwrap();
     let handler = Arc::new(Mutex::new(handler::Buffer::new()));
 
     collector = collector.add_matcher(Box::new(first_matcher), &[handler.clone()]);
@@ -70,7 +70,7 @@ pub fn combinator(c: &mut Criterion) {
     let mut collector = Collector::new();
 
     let first_matcher = matcher::Combinator::new(matcher::Depth::new(1, None));
-    let second_matcher = matcher::Combinator::new(matcher::Simple::new(r#"{"logs"}[]"#));
+    let second_matcher = matcher::Combinator::new(matcher::Simple::new(r#"{"logs"}[]"#).unwrap());
     let first_combo = first_matcher.clone() | second_matcher.clone();
     let second_combo = first_matcher & !second_matcher;
     let handler = Arc::new(Mutex::new(handler::Buffer::new()));

--- a/streamson-lib/src/error.rs
+++ b/streamson-lib/src/error.rs
@@ -67,9 +67,36 @@ impl fmt::Display for IncorrectInput {
         )
     }
 }
+
+/// Path related error
+#[derive(Debug, PartialEq, Clone)]
+pub struct Path {
+    path: String,
+}
+
+impl Path {
+    pub fn new<T>(path: T) -> Self
+    where
+        T: ToString,
+    {
+        Self {
+            path: path.to_string(),
+        }
+    }
+}
+
+impl Error for Path {}
+
+impl fmt::Display for Path {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Wrong path '{}'", self.path)
+    }
+}
+
 /// Handler related errors
 #[derive(Debug)]
 pub enum General {
+    Path(Path),
     Handler(Handler),
     Matcher(Matcher),
     Utf8Error(Utf8Error),
@@ -81,6 +108,7 @@ impl Error for General {}
 impl fmt::Display for General {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Self::Path(err) => err.fmt(f),
             Self::Handler(err) => err.fmt(f),
             Self::Matcher(err) => err.fmt(f),
             Self::Utf8Error(err) => err.fmt(f),

--- a/streamson-lib/src/handler/buffer.rs
+++ b/streamson-lib/src/handler/buffer.rs
@@ -7,7 +7,7 @@
 //!
 //! let buffer_handler = Arc::new(Mutex::new(handler::Buffer::new()));
 //!
-//! let matcher = matcher::Simple::new(r#"{"users"}[]{"name"}"#);
+//! let matcher = matcher::Simple::new(r#"{"users"}[]{"name"}"#).unwrap();
 //!
 //! let mut collector = Collector::new();
 //!

--- a/streamson-lib/src/handler/file.rs
+++ b/streamson-lib/src/handler/file.rs
@@ -133,7 +133,7 @@ mod tests {
         let tmp_path = NamedTempFile::new().unwrap().into_temp_path();
         let str_path = tmp_path.to_str().unwrap();
 
-        let matcher = matcher::Simple::new(r#"{"aa"}[]"#);
+        let matcher = matcher::Simple::new(r#"{"aa"}[]"#).unwrap();
         let handler = handler::File::new(str_path).unwrap();
 
         let output = make_output(
@@ -160,7 +160,7 @@ mod tests {
         let tmp_path = NamedTempFile::new().unwrap().into_temp_path();
         let str_path = tmp_path.to_str().unwrap();
 
-        let matcher = matcher::Simple::new(r#"{"aa"}[]"#);
+        let matcher = matcher::Simple::new(r#"{"aa"}[]"#).unwrap();
         let handler = handler::File::new(str_path).unwrap().set_separator("XXX");
 
         let output = make_output(
@@ -178,7 +178,7 @@ mod tests {
         let tmp_path = NamedTempFile::new().unwrap().into_temp_path();
         let str_path = tmp_path.to_str().unwrap();
 
-        let matcher = matcher::Simple::new(r#"{"aa"}[]"#);
+        let matcher = matcher::Simple::new(r#"{"aa"}[]"#).unwrap();
         let handler = handler::File::new(str_path).unwrap().set_show_path(true);
 
         let output = make_output(

--- a/streamson-lib/src/lib.rs
+++ b/streamson-lib/src/lib.rs
@@ -16,8 +16,8 @@
 //! );
 //! let stdout_handler = Arc::new(Mutex::new(handler::PrintLn::new()));
 //!
-//! let first_matcher = matcher::Simple::new(r#"{"users"}[]"#);
-//! let second_matcher = matcher::Simple::new(r#"{"groups"}[]"#);
+//! let first_matcher = matcher::Simple::new(r#"{"users"}[]"#).unwrap();
+//! let second_matcher = matcher::Simple::new(r#"{"groups"}[]"#).unwrap();
 //!
 //! let mut collector = Collector::new();
 //!
@@ -51,7 +51,7 @@
 //! let stdout_handler = Arc::new(Mutex::new(handler::PrintLn::new()));
 //!
 //! let first_matcher = matcher::Depth::new(1, Some(2));
-//! let second_matcher = matcher::Simple::new(r#"{"users"}[]"#);
+//! let second_matcher = matcher::Simple::new(r#"{"users"}[]"#).unwrap();
 //! let matcher = matcher::Combinator::new(first_matcher) |
 //!     matcher::Combinator::new(second_matcher);
 //!

--- a/streamson-lib/src/matcher.rs
+++ b/streamson-lib/src/matcher.rs
@@ -10,6 +10,8 @@ pub use combinator::Combinator;
 pub use depth::Depth;
 pub use simple::Simple;
 
+use crate::path::Path;
+
 /// Common Matcher trait
 pub trait MatchMaker: fmt::Debug + Send {
     /// Check whether the path matches
@@ -18,5 +20,5 @@ pub trait MatchMaker: fmt::Debug + Send {
     ///
     /// # Returns
     /// * `true` if path matches, `false` otherwise
-    fn match_path(&self, path: &str) -> bool;
+    fn match_path(&self, path: &Path) -> bool;
 }

--- a/streamson-tokio/README.md
+++ b/streamson-tokio/README.md
@@ -13,8 +13,8 @@ So that you can easily split jsons using asynchronous rust.
  use tokio_util::codec::FramedRead;
 
  let mut file = fs::File::open("/tmp/large.json").await?;
- let matcher = matcher::Combinator::new(matcher::Simple::new(r#"{"users"}[]"#))
-     | matcher::Combinator::new(matcher::Simple::new(r#"{"groups"}[]"#));
+ let matcher = matcher::Combinator::new(matcher::Simple::new(r#"{"users"}[]"#).unwrap())
+     | matcher::Combinator::new(matcher::Simple::new(r#"{"groups"}[]"#).unwrap());
  let extractor = Extractor::new(matcher);
  let mut output = FramedRead::new(file, extractor);
  while let Some(item) = output.next().await {

--- a/streamson-tokio/src/decoder.rs
+++ b/streamson-tokio/src/decoder.rs
@@ -19,8 +19,8 @@ use tokio_util::codec::Decoder;
 ///
 /// async fn process() -> Result<(), error::General> {
 ///     let mut file = fs::File::open("/tmp/large.json").await?;
-///     let matcher = matcher::Combinator::new(matcher::Simple::new(r#"{"users"}[]"#))
-///         | matcher::Combinator::new(matcher::Simple::new(r#"{"groups"}[]"#));
+///     let matcher = matcher::Combinator::new(matcher::Simple::new(r#"{"users"}[]"#).unwrap())
+///         | matcher::Combinator::new(matcher::Simple::new(r#"{"groups"}[]"#).unwrap());
 ///     let extractor = Extractor::new(matcher);
 ///     let mut output = FramedRead::new(file, extractor);
 ///     while let Some(item) = output.next().await {
@@ -86,8 +86,8 @@ mod tests {
     async fn basic() {
         let cursor =
             Cursor::new(br#"{"users": ["mike","john"], "groups": ["admin", "staff"]}"#.to_vec());
-        let matcher = matcher::Combinator::new(matcher::Simple::new(r#"{"users"}[]"#))
-            | matcher::Combinator::new(matcher::Simple::new(r#"{"groups"}[]"#));
+        let matcher = matcher::Combinator::new(matcher::Simple::new(r#"{"users"}[]"#).unwrap())
+            | matcher::Combinator::new(matcher::Simple::new(r#"{"groups"}[]"#).unwrap());
         let extractor = Extractor::new(matcher);
         let mut output = FramedRead::new(cursor, extractor);
 


### PR DESCRIPTION
* added abstraction Path over Vec<Element>
* matcher's `match_path` requires &Path not String
* Emitter Output only position not path string
* Simple matcher `new` returns Result<Self, ...>
* Collector match storing logic updated